### PR TITLE
Use more appropriate license icons

### DIFF
--- a/public/simulations.html
+++ b/public/simulations.html
@@ -89,7 +89,7 @@
 
                         <v-app-bar>
                             <v-btn style="width:33%" href="https://github.com/sleepdiary/info/">
-                                <v-icon>mdi-github</v-icon>
+                                <v-icon>mdi-code-tags</v-icon>
                                 <span>Source code</span>
                             </v-btn>
                             <v-btn style="width:33%" href="https://github.com/sleepdiary/info/blob/main/LICENSE">

--- a/public/simulations.html
+++ b/public/simulations.html
@@ -93,7 +93,7 @@
                                 <span>Source code</span>
                             </v-btn>
                             <v-btn style="width:33%" href="https://github.com/sleepdiary/info/blob/main/LICENSE">
-                                <v-icon>mdi-license</v-icon>
+                                <v-icon>mdi-copyright</v-icon>
                                 <span>License</span>
                             </v-btn>
                             <v-btn style="width:33%" href="https://github.com/sleepdiary/info/issues/new">


### PR DESCRIPTION
* s/mdi-license/mdi-copyright/g
* s/mdi-github/mdi-code-tags/g

These seem to be more widely used by other projects